### PR TITLE
Feature/invert show more less render responsability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ React component that uses the css line clamping to truncate given text in specif
 npm install react-multiline-clamp
 ```
 
-#### Basic example
+### Basic example
 
 ```jsx
 import Clamp from 'react-multiline-clamp';
@@ -63,16 +63,16 @@ const MyComponent = () => {
 
 ## API
 
-|      Name       |          Type           | Default  |                                                                   Description                                                                   |
-| :-------------: | :---------------------: | :------: | :---------------------------------------------------------------------------------------------------------------------------------------------: |
-|    children     |         Element         |          |                    The expected element to which the ellipsis would be applied. It could be plain text or any HTML/Component                    |
-|      lines      |         Number          |    2     |                                             The number of lines we want the text to be truncated to                                             |
-|    maxLines     |         Number          |    8     |                                  The maximum number of lines we want to show after clicking on showMore button                                  |
-|   withTooltip   |         Boolean         |   true   |                                              Indicates if we want the text to have a tooltip title                                              |
-|   withToggle    |         Boolean         |  false   |                                             Indicates if we want to have the show more/less actions                                             |
-| showMoreElement |         Element         |          |                                                   Element that triggers the show more action                                                    |
-| showLessElement |         Element         |          |                                                   Element that triggers the show less action                                                    |
-|   onShowMore    | (isExpanded) => Boolean | () => {} | A callback function that gets calls every time we click on the show more/less buttons. It returns whether the text is expanded or not (Boolean) |
+|      Name       |          Type           |               Default               |                                                                   Description                                                                   |
+| :-------------: | :---------------------: | :---------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------: |
+|    children     |         Element         |                                     |                    The expected element to which the ellipsis would be applied. It could be plain text or any HTML/Component                    |
+|      lines      |         Number          |                  2                  |                                             The number of lines we want the text to be truncated to                                             |
+|    maxLines     |         Number          |                  8                  |                                  The maximum number of lines we want to show after clicking on showMore button                                  |
+|   withTooltip   |         Boolean         |                true                 |                                              Indicates if we want the text to have a tooltip title                                              |
+|   withToggle    |         Boolean         |                false                |                                             Indicates if we want to have the show more/less actions                                             |
+| showMoreElement |         Element         | <button type="button">More</button> |                                                   Element that triggers the show more action                                                    |
+| showLessElement |         Element         | <button type="button">Less</button> |                                                   Element that triggers the show less action                                                    |
+|   onShowMore    | (isExpanded) => Boolean |              () => {}               | A callback function that gets calls every time we click on the show more/less buttons. It returns whether the text is expanded or not (Boolean) |
 
 #### [See browser support](https://caniuse.com/#feat=mdn-css_properties_-webkit-line-clamp)
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ React component that uses the css line clamping to truncate given text in specif
 [Codesandbox demo](https://codesandbox.io/embed/react-multiline-clamp-luw4q)
 
 ## Features
-- 🎉 Uses the css line clamp property
-- 😱 It works both with plain text and HTML/Components
-- 💥 Integrated show more/less behaviour
-- 👂 Listens to text and lines changes and responds accordingly
-- ⚙️ Easy-to-use component API
-- 🌳 Tiny size, only 1.4kb
+
+-   🎉 Uses the css line clamp property
+-   😱 It works both with plain text and HTML/Components
+-   💥 Integrated show more/less behaviour
+-   👂 Listens to text and lines changes and responds accordingly
+-   ⚙️ Easy-to-use component API
+-   🌳 Tiny size, only 1.4kb
 
 ## Installation
 
@@ -24,39 +25,55 @@ npm install react-multiline-clamp
 import Clamp from 'react-multiline-clamp';
 
 const MyComponent = () => {
-  return (
-    <Clamp withTooltip lines={2}>
-      <p>Multiline text</p>
-    </Clamp>
-  );
+    return (
+        <Clamp withTooltip lines={2}>
+            <p>Multiline text</p>
+        </Clamp>
+    );
 };
 ```
 
-### With show more/less
+### With show more/less behaviour
 
 ```jsx
 import Clamp from 'react-multiline-clamp';
 
 const MyComponent = () => {
-  return (
-    <Clamp withTooltip lines={2} withToggle maxLines={11} >
-      <p>Multiline text</p>
-    </Clamp>
-  );
+    return (
+        <Clamp
+            lines={2}
+            maxLines={6}
+            withToggle
+            showMoreElement={({ toggle }) => (
+                <button type="button" onClick={toggle}>
+                    Show more
+                </button>
+            )}
+            showLessElement={({ toggle }) => (
+                <span type="button" onClick={toggle}>
+                    menossssss
+                </span>
+            )}
+        >
+            <p>Multiline text</p>
+        </Clamp>
+    );
 };
 ```
 
 ## API
 
-|     Name    |           Type          |                           Default                           |                                                                   Description                                                                   |
-|:-----------:|:-----------------------:|:-----------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------:|
-|   children  |         Element         |                                                             | The expected element to which the ellipsis would be applied. It could be plain text or any HTML/Component                                       |
-|    lines    |          Number         |                              2                              | The number of lines we want the text to be truncated to                                                                                         |
-|   maxLines  |          Number         |                              8                              | The maximum number of lines we want to show after clicking on showMore button                                                                   |
-| withTooltip |         Boolean         |                             true                            | Indicates if we want the text to have a tooltip title                                                                                           |
-|  withToggle |         Boolean         |                            false                            | Indicates if we want to have the show more/less buttons                                                                                         |
-|    texts    |          Object         |    texts: {     showMore: 'More',     showLess: 'Less'    } | The texts of the show more/less buttons                                                                                                         |
-|  onShowMore | (isExpanded) => Boolean |                           () => {}                          | A callback function that gets calls every time we click on the show more/less buttons. It returns whether the text is expanded or not (Boolean) |
+|      Name       |          Type           | Default  |                                                                   Description                                                                   |
+| :-------------: | :---------------------: | :------: | :---------------------------------------------------------------------------------------------------------------------------------------------: |
+|    children     |         Element         |          |                    The expected element to which the ellipsis would be applied. It could be plain text or any HTML/Component                    |
+|      lines      |         Number          |    2     |                                             The number of lines we want the text to be truncated to                                             |
+|    maxLines     |         Number          |    8     |                                  The maximum number of lines we want to show after clicking on showMore button                                  |
+|   withTooltip   |         Boolean         |   true   |                                              Indicates if we want the text to have a tooltip title                                              |
+|   withToggle    |         Boolean         |  false   |                                             Indicates if we want to have the show more/less actions                                             |
+| showMoreElement |         Element         |          |                                                   Element that triggers the show more action                                                    |
+| showLessElement |         Element         |          |                                                   Element that triggers the show less action                                                    |
+|   onShowMore    | (isExpanded) => Boolean | () => {} | A callback function that gets calls every time we click on the show more/less buttons. It returns whether the text is expanded or not (Boolean) |
+
 #### [See browser support](https://caniuse.com/#feat=mdn-css_properties_-webkit-line-clamp)
 
 ##### Author: Mikel Parra <mikelpmc@gmail.com> | <http://github.com/mikelpmc>

--- a/src/Example.js
+++ b/src/Example.js
@@ -45,7 +45,6 @@ function Example() {
                         menossssss
                     </span>
                 )}
-                texts={{ showMore: 'Moreeee', showLess: 'Menos' }}
                 lines={lines}
                 maxLines={8}
                 withToggle

--- a/src/Example.js
+++ b/src/Example.js
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import Clamp from "./lib";
+import React, { useState } from 'react';
+import Clamp from './lib';
 
 const initialText = `Lorem ipsum dolor sit amet consectetur adipisicing elit.
 Illum perspiciatis ea consequuntur ipsum deleniti placeat
@@ -22,24 +22,34 @@ function Example() {
                     value={text}
                     cols={4}
                     rows={4}
-                    onChange={(ev) => setText(ev.target.value)}
-                    style={{ width: "100%", height: "150px" }}
+                    onChange={ev => setText(ev.target.value)}
+                    style={{ width: '100%', height: '150px' }}
                 />
             </div>
             <div>
                 <input
                     type="text"
                     value={lines}
-                    onChange={(ev) => setLines(ev.target.value)}
+                    onChange={ev => setLines(ev.target.value)}
                 />
             </div>
 
             <Clamp
-                texts={{ showMore: "Moreeee", showLess: "Menos" }}
+                showMoreElement={({ toggle }) => (
+                    <button type="button" onClick={toggle}>
+                        Show more
+                    </button>
+                )}
+                showLessElement={({ toggle }) => (
+                    <span type="button" onClick={toggle}>
+                        menossssss
+                    </span>
+                )}
+                texts={{ showMore: 'Moreeee', showLess: 'Menos' }}
                 lines={lines}
                 maxLines={8}
                 withToggle
-                onShowMore={(show) => console.log(show)}
+                onShowMore={show => console.log(show)}
             >
                 <p>{text}</p>
             </Clamp>

--- a/src/lib/clamp.js
+++ b/src/lib/clamp.js
@@ -1,6 +1,6 @@
-import React, { useState, Fragment, useEffect } from "react";
-import isCssEllipsisApplied from "./utils/isCssEllipsisApplied";
-import TruncatedElement from "./truncatedElement";
+import React, { useState, Fragment, useEffect } from 'react';
+import isCssEllipsisApplied from './utils/isCssEllipsisApplied';
+import TruncatedElement from './truncatedElement';
 
 const Clamp = ({
     children,
@@ -8,40 +8,38 @@ const Clamp = ({
     maxLines = 8,
     withTooltip = true,
     withToggle = false,
-    texts = {
-        showMore: "More",
-        showLess: "Less",
-    },
-    onShowMore = () => {},
+    showMoreElement,
+    showLessElement,
+    onShowMore = () => {}
 }) => {
     const [sLines, setLines] = useState(lines);
     const [isExpanded, setIsExpanded] = useState(false);
     const [showMore, setShowMore] = useState(false);
 
-    const handleToggleShowMore = (show) => {
+    const handleToggleShowMore = show => {
         const newLines = show ? maxLines : lines;
 
-        setShowMore((showMore) => !showMore);
-        setIsExpanded((isExpanded) => !isExpanded);
+        setShowMore(showMore => !showMore);
+        setIsExpanded(isExpanded => !isExpanded);
         setLines(newLines);
 
         onShowMore(show);
     };
 
-    const handleConfigElement = (elem) => {
+    const handleConfigElement = elem => {
         if (!elem) return;
 
         if (isCssEllipsisApplied(elem)) {
             if (withTooltip) {
                 const title = elem.textContent;
-                elem.setAttribute("title", title);
+                elem.setAttribute('title', title);
             }
 
             if (withToggle && !showMore && !isExpanded) {
                 setShowMore(true);
             }
         } else {
-            elem.removeAttribute("title");
+            elem.removeAttribute('title');
             setShowMore(false);
         }
     };
@@ -58,23 +56,12 @@ const Clamp = ({
                 {children}
             </TruncatedElement>
 
-            {showMore && !isExpanded && (
-                <button
-                    type="button"
-                    onClick={() => handleToggleShowMore(true)}
-                >
-                    {texts.showMore}
-                </button>
-            )}
+            {showMore &&
+                !isExpanded &&
+                showMoreElement({ toggle: () => handleToggleShowMore(true) })}
 
-            {isExpanded && (
-                <button
-                    type="button"
-                    onClick={() => handleToggleShowMore(false)}
-                >
-                    {texts.showLess}
-                </button>
-            )}
+            {isExpanded &&
+                showLessElement({ toggle: () => handleToggleShowMore(false) })}
         </Fragment>
     );
 };

--- a/src/lib/clamp.js
+++ b/src/lib/clamp.js
@@ -2,14 +2,26 @@ import React, { useState, Fragment, useEffect } from 'react';
 import isCssEllipsisApplied from './utils/isCssEllipsisApplied';
 import TruncatedElement from './truncatedElement';
 
+const defaultShowMoreElement = ({ toggle }) => (
+    <button type="button" onClick={toggle}>
+        More
+    </button>
+);
+
+const defaultShowLessElement = ({ toggle }) => (
+    <button type="button" onClick={toggle}>
+        Less
+    </button>
+);
+
 const Clamp = ({
     children,
     lines = 2,
     maxLines = 8,
     withTooltip = true,
     withToggle = false,
-    showMoreElement,
-    showLessElement,
+    showMoreElement = defaultShowMoreElement,
+    showLessElement = defaultShowLessElement,
     onShowMore = () => {}
 }) => {
     const [sLines, setLines] = useState(lines);


### PR DESCRIPTION
Motivation:

Have a more flexible API that allows to pass any element/component you want from the outside to the component to act as the show more/less buttons.

The new prop gives you back an object with `open` boolean state and `toggle` function for you to use them.

```js
 <Clamp
    showMoreElement={({ toggle }) => (
        <button type="button" onClick={toggle}>
            Show more
        </button>
    )}
    showLessElement={({ toggle }) => (
        <span type="button" onClick={toggle}>
            menossssss
        </span>
    )}
    lines={lines}
    maxLines={8}
    withToggle
    onShowMore={show => console.log(show)}
>
    <p>{text}</p>
</Clamp>
```